### PR TITLE
Fix filesize checking

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func uploadFileHandler() http.HandlerFunc {
 		}
 
 		// parse and validate file and post parameters
-		file, fileHeader, err := r.FormFile("uploadfile")
+		file, fileHeader, err := r.FormFile("uploadFile")
 		if err != nil {
 			renderError(w, "INVALID_FILE", http.StatusBadRequest)
 			return

--- a/main.go
+++ b/main.go
@@ -26,20 +26,27 @@ func main() {
 
 func uploadFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// validate file size
-		r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
 		if err := r.ParseMultipartForm(maxUploadSize); err != nil {
-			renderError(w, "FILE_TOO_BIG", http.StatusBadRequest)
+			fmt.Printf("Could not parse multipart form: %v\n", err)
+			renderError(w, "CANT_PARSE_FORM", http.StatusInternalServerError)
 			return
 		}
 
 		// parse and validate file and post parameters
-		file, _, err := r.FormFile("uploadFile")
+		file, fileHeader, err := r.FormFile("uploadfile")
 		if err != nil {
 			renderError(w, "INVALID_FILE", http.StatusBadRequest)
 			return
 		}
 		defer file.Close()
+		// Get and print out file size
+		fileSize := fileHeader.Size
+		fmt.Printf("File size (bytes): %v\n", fileSize)
+		// validate file size
+		if fileSize > maxUploadSize {
+			renderError(w, "FILE_TOO_BIG", http.StatusBadRequest)
+			return
+		}
 		fileBytes, err := ioutil.ReadAll(file)
 		if err != nil {
 			renderError(w, "INVALID_FILE", http.StatusBadRequest)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"html/template"
 )
 
 const maxUploadSize = 2 * 1024 * 1024 // 2 mb
@@ -26,6 +27,11 @@ func main() {
 
 func uploadFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			t, _ := template.ParseFiles("upload.gtpl")
+			t.Execute(w, nil)
+			return
+		}
 		if err := r.ParseMultipartForm(maxUploadSize); err != nil {
 			fmt.Printf("Could not parse multipart form: %v\n", err)
 			renderError(w, "CANT_PARSE_FORM", http.StatusInternalServerError)

--- a/upload.gtpl
+++ b/upload.gtpl
@@ -1,0 +1,11 @@
+<html>
+<head>
+	<title>Upload file</title>
+</head>
+<body>
+<form enctype="multipart/form-data" action="http://localhost:8080/upload" method="post">
+	<input type="file" name="uploadFile" />
+	<input type="submit" value="upload" />
+</form>
+</body>
+</html>


### PR DESCRIPTION
By using `http.MaxBytesReader`, you're setting the maximum number of bytes **from the request** body that the handler will be able to read.

Furthermore, `r.ParseMultipartForm(maxUploadSize)` will set the maximum number of  bytes of the body file parts that **the handler will store in memory**, with the remainder stored on disk in temporary files. So, it is not really checking the file size, and if you upload a file with exactly 2 mb in size, or a little less (say, 2040 kilobytes), you will get a `FILE_TOO_BIG` error, since the size of the whole request body was limited to no more than 2 mb. A common application would probably have more input fields, increasing even more the size of the request body...

The easiest way to validate the file size is by inspecting the header returned by `r.FormFile`, which holds its size in the `Size` field.

I've read your blog post https://zupzup.org/go-http-file-upload-download/ and it needs some updates, so I wrote out the fixes there too:

After 

> First, we define the handler:

```go
func uploadFileHandler() http.HandlerFunc {
    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
```

would go:

> Then, we parse the multipart/form-data that comes in the request body by calling ParseMultiPartForm on the request object and passing to it the maxUploadSize constant as a parameter.
Request.ParseMultipartFormData, according to the [docs](https://godoc.org/net/http#Request.ParseMultipartForm), parses a request body as multipart/form-data. The whole request body is parsed and up to a total of maxMemory bytes of its file parts are stored in memory, with the remainder stored on disk in temporary files.
Any errors returned from this method should count as an internal server error, so we check that case and return the aproppiate error message and status code.  Errors are handled with a simple renderError helper, which returns the given error message and an according HTTP status code.

```go
if err := r.ParseMultipartForm(maxUploadSize); err != nil {
	fmt.Printf("Could not parse multipart form: %v\n", err)
	renderError(w, "CANT_PARSE_FORM", http.StatusInternalServerError)
	return
}
```

> If the multipart/form-data could be parsed successfully, we will check and parse the form parameter type and the uploadFile and read the file.

```go
file, fileheader, err := r.FormFile("uploadFile")
    if err != nil {
        renderError(w, "INVALID_FILE", http.StatusBadRequest)
        return
    }
defer file.Close()
```

> Then, we validate the file size comparing the maxUploadSize constant and the Size field of the header returned by r.FormFile. For debugging purposes, we'll print out the file size in the console.
If the file size is greater than maxUploadSize, then we will send a "FILE_TOO_BIG" error to the client, along with a StatusBadRequest code.

```go
// Get and print out file size
fileSize := fileHeader.Size
fmt.Printf("File size (bytes): %v\n", fileSize)
// validate file size
if fileSize > maxUploadSize {
	renderError(w, "FILE_TOO_BIG", http.StatusBadRequest)
	return
}
```

> In this example, for clarity, we won’t use any fanciness with the great io.Reader and io.Writer interfaces, but simply read the file into a byte array, which we will later write out again.

Everything else would remain unchanged.